### PR TITLE
Fix handling of URLs with invitation code

### DIFF
--- a/myalbum_downloader.py
+++ b/myalbum_downloader.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from dateutil.parser import parse
 
 def download_image(inputurl):
-    album_id = re.search("\/album\/(.+[^\/])", inputurl).group(1)
+    album_id = re.search("\/album\/([a-z0-9]*)", inputurl, re.I).group(1)
     r = requests.get(f"https://myalbum.com/api/v2/album/{album_id}/")
     rootJson = r.json()
     albumTitle = rootJson["title"]


### PR DESCRIPTION
URLs in the form https://myalbum.com/album/xyz/?invite=abc were mishandled. The album-ID was determined to be 'xyz/?invite=abc' which in turn led to strange results downloading EXIF-metadata.